### PR TITLE
Fix missing scriptFile in functions

### DIFF
--- a/api/DownloadSas/function.json
+++ b/api/DownloadSas/function.json
@@ -12,5 +12,6 @@
       "direction": "out",
       "name": "res"
     }
-  ]
+  ],
+  "scriptFile": "index.js"
 } 

--- a/api/GenerateQr/function.json
+++ b/api/GenerateQr/function.json
@@ -12,5 +12,7 @@
       "direction": "out",
       "name": "res"
     }
-  ]
+  ],
+  "scriptFile": "index.js"
 }
+

--- a/api/IssueSas/function.json
+++ b/api/IssueSas/function.json
@@ -12,5 +12,6 @@
       "direction": "out",
       "name": "res"
     }
-  ]
+  ],
+  "scriptFile": "index.js"
 } 


### PR DESCRIPTION
## Summary
- add `scriptFile` entry in `DownloadSas`, `IssueSas`, and `GenerateQr`

## Testing
- `npm test` (root)
- `npm install` && `npm test` in `api`
- `npm install` && `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6841597cd3588325a50b08a77c579b53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration for several API functions to specify the script file used for execution. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->