### PR TITLE
Add QR code generator UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Parameters:
 
 The API returns a signed URL for downloading the watermarked image.
 
+### QR Code API
+
+`GET /api/generate?text=YOUR_TEXT`
+
+Parameters:
+
+- `text`: string to encode in the QR code
+
+The API returns the QR code image (PNG by default).
+
 ## Development
 
 ```bash

--- a/api/GenerateQr/function.json
+++ b/api/GenerateQr/function.json
@@ -5,7 +5,8 @@
       "type": "httpTrigger",
       "direction": "in",
       "methods": ["get", "post"],
-      "name": "req"
+      "name": "req",
+      "route": "generate"
     },
     {
       "type": "http",

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -20,7 +20,8 @@ This document tracks implemented features from the PRD.
 - PRD의 "Future Considerations" 섹션에 명시된 기능(동영상 변환, 고급 AI 편집, 다국어 지원, B2B/B2C API 제공) 구현을 검토합니다.
 - `AZURE_SETUP.md`의 지침에 따라 관리자 비밀번호 해시와 기타 환경 변수를 설정합니다.
 - 배포 후 `generate-admin-hash.js`로 새 비밀번호 해시를 생성해 보안을 유지합니다.
-- 프런트엔드에서 Watermark API와 QR 코드 생성 기능을 사용할 수 있도록 UI를 추가합니다.
+- [x] 프런트엔드에 QR 코드 생성 UI를 추가하여 Generate API와 연동했습니다.
+- [ ] Watermark API UI 연동을 완료합니다.
 - `openTool('image-resize')`를 실제 이미지 크기 조정 모달로 구현하고 Convert API에 연동합니다.
 - 관리자 패널의 `generateWebsiteCode()` 기능을 완성하여 편집한 콘텐츠를 정적 HTML로 내보냅니다.
 - Cloudflare R2 저장소 정리 함수(`CleanupStorage`)를 타이머 트리거로 배포하여 자동화합니다.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -37,6 +37,10 @@ function loadDefaultContent() {
                     <div class="tool-name">부분 확대</div>
                     <div class="tool-desc">영역 지정 확대</div>
                 </div>
+                <div class="tool-item" onclick="showQrModal()">
+                    <div class="tool-name">QR 코드 생성</div>
+                    <div class="tool-desc">텍스트로 QR 이미지 만들기</div>
+                </div>
             </div>
         </div>
     `;
@@ -260,6 +264,38 @@ async function startZoom() {
 
     } catch (err) {
         document.getElementById('zoomStatus').textContent = `오류: ${err.message}`;
+    }
+}
+
+function showQrModal() {
+    document.getElementById('qrModal').classList.add('show');
+}
+
+function closeQrModal() {
+    document.getElementById('qrModal').classList.remove('show');
+    document.getElementById('qrText').value = '';
+    document.getElementById('qrResult').style.display = 'none';
+}
+
+async function generateQr() {
+    const text = document.getElementById('qrText').value.trim();
+    if (!text) {
+        alert('텍스트를 입력하세요.');
+        return;
+    }
+
+    try {
+        const response = await fetch(`${API_BASE}/api/generate?text=${encodeURIComponent(text)}`);
+        if (!response.ok) throw new Error(await response.text());
+
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+
+        document.getElementById('qrImage').src = url;
+        document.getElementById('qrDownload').href = url;
+        document.getElementById('qrResult').style.display = 'block';
+    } catch (err) {
+        alert('QR 코드 생성 실패: ' + err.message);
     }
 }
 
@@ -775,3 +811,6 @@ window.startZoom = startZoom;
 window.showAdminModal = showAdminModal;
 window.closeAdminModal = closeAdminModal;
 window.checkAdminPassword = checkAdminPassword;
+window.showQrModal = showQrModal;
+window.closeQrModal = closeQrModal;
+window.generateQr = generateQr;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -231,6 +231,26 @@
             </div>
         </div>
     </div>
+
+    <!-- QR Code Modal -->
+    <div class="converter-modal" id="qrModal">
+        <div class="converter-content">
+            <button class="close-button" onclick="closeQrModal()">×</button>
+            <h2 class="converter-header">🔗 QR 코드 생성</h2>
+
+            <div class="converter-section">
+                <label class="converter-label">텍스트 입력</label>
+                <input type="text" id="qrText" class="file-input" placeholder="https://example.com">
+            </div>
+
+            <button id="qrButton" class="convert-button" onclick="generateQr()">QR 생성</button>
+
+            <div class="progress-section" id="qrResult" style="display:none;">
+                <img id="qrImage" alt="QR Code" style="max-width:200px; display:block; margin:10px auto;">
+                <a id="qrDownload" href="#" download="qr.png" class="convert-button" style="margin-top:10px;">다운로드</a>
+            </div>
+        </div>
+    </div>
     <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose QR code API at `/api/generate`
- create a QR generator modal and JS logic
- list new tool in the default UI
- document QR Code API in README
- mark progress in docs

## Testing
- `npm test` (root)
- `npm test` in `api` after `npm install`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684238eb578c832582d308582aa9055a