### PR TITLE
Implement Watermark UI

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -21,7 +21,7 @@ This document tracks implemented features from the PRD.
 - `AZURE_SETUP.md`의 지침에 따라 관리자 비밀번호 해시와 기타 환경 변수를 설정합니다.
 - 배포 후 `generate-admin-hash.js`로 새 비밀번호 해시를 생성해 보안을 유지합니다.
 - [x] 프런트엔드에 QR 코드 생성 UI를 추가하여 Generate API와 연동했습니다.
-- [ ] Watermark API UI 연동을 완료합니다.
+- [x] Watermark API UI 연동을 완료합니다.
 - `openTool('image-resize')`를 실제 이미지 크기 조정 모달로 구현하고 Convert API에 연동합니다.
 - 관리자 패널의 `generateWebsiteCode()` 기능을 완성하여 편집한 콘텐츠를 정적 HTML로 내보냅니다.
 - Cloudflare R2 저장소 정리 함수(`CleanupStorage`)를 타이머 트리거로 배포하여 자동화합니다.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -37,6 +37,10 @@ function loadDefaultContent() {
                     <div class="tool-name">부분 확대</div>
                     <div class="tool-desc">영역 지정 확대</div>
                 </div>
+                <div class="tool-item" onclick="showWatermarkModal()">
+                    <div class="tool-name">이미지 워터마크</div>
+                    <div class="tool-desc">텍스트 삽입</div>
+                </div>
                 <div class="tool-item" onclick="showQrModal()">
                     <div class="tool-name">QR 코드 생성</div>
                     <div class="tool-desc">텍스트로 QR 이미지 만들기</div>
@@ -275,6 +279,49 @@ function closeQrModal() {
     document.getElementById('qrModal').classList.remove('show');
     document.getElementById('qrText').value = '';
     document.getElementById('qrResult').style.display = 'none';
+}
+
+function showWatermarkModal() {
+    document.getElementById('watermarkModal').classList.add('show');
+}
+
+function closeWatermarkModal() {
+    document.getElementById('watermarkModal').classList.remove('show');
+    document.getElementById('watermarkFile').value = '';
+    document.getElementById('watermarkText').value = '';
+    document.getElementById('watermarkResult').style.display = 'none';
+}
+
+async function startWatermark() {
+    const fileInput = document.getElementById('watermarkFile');
+    const text = document.getElementById('watermarkText').value.trim();
+    const position = document.getElementById('watermarkPosition').value;
+    const opacity = document.getElementById('watermarkOpacity').value;
+
+    if (!fileInput.files[0] || !text) {
+        alert('이미지와 텍스트를 입력하세요.');
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', fileInput.files[0]);
+    formData.append('text', text);
+    formData.append('position', position);
+    formData.append('opacity', opacity);
+
+    try {
+        const response = await fetch(`${API_BASE}/api/watermark`, {
+            method: 'POST',
+            body: formData
+        });
+        if (!response.ok) throw new Error(await response.text());
+
+        const result = await response.json();
+        document.getElementById('watermarkDownload').href = result.downloadUrl;
+        document.getElementById('watermarkResult').style.display = 'block';
+    } catch (err) {
+        alert('워터마크 실패: ' + err.message);
+    }
 }
 
 async function generateQr() {
@@ -814,3 +861,6 @@ window.checkAdminPassword = checkAdminPassword;
 window.showQrModal = showQrModal;
 window.closeQrModal = closeQrModal;
 window.generateQr = generateQr;
+window.showWatermarkModal = showWatermarkModal;
+window.closeWatermarkModal = closeWatermarkModal;
+window.startWatermark = startWatermark;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -251,6 +251,46 @@
             </div>
         </div>
     </div>
+
+    <!-- Watermark Modal -->
+    <div class="converter-modal" id="watermarkModal">
+        <div class="converter-content">
+            <button class="close-button" onclick="closeWatermarkModal()">×</button>
+            <h2 class="converter-header">💧 워터마크</h2>
+
+            <div class="converter-section">
+                <label class="converter-label">이미지 선택</label>
+                <input type="file" id="watermarkFile" class="file-input" accept="image/*">
+            </div>
+
+            <div class="converter-section">
+                <label class="converter-label">텍스트</label>
+                <input type="text" id="watermarkText" class="file-input" placeholder="Sample">
+            </div>
+
+            <div class="converter-section">
+                <label class="converter-label">위치</label>
+                <select id="watermarkPosition" class="format-selector">
+                    <option value="bottom-right">오른쪽 하단</option>
+                    <option value="bottom-left">왼쪽 하단</option>
+                    <option value="top-right">오른쪽 상단</option>
+                    <option value="top-left">왼쪽 상단</option>
+                    <option value="center">중앙</option>
+                </select>
+            </div>
+
+            <div class="converter-section">
+                <label class="converter-label">투명도</label>
+                <input type="number" id="watermarkOpacity" class="size-input" min="0" max="1" step="0.1" value="0.5">
+            </div>
+
+            <button id="watermarkButton" class="convert-button" onclick="startWatermark()">워터마크 적용</button>
+
+            <div class="progress-section" id="watermarkResult" style="display:none;">
+                <a id="watermarkDownload" href="#" target="_blank" class="convert-button" style="margin-top:10px;">다운로드</a>
+            </div>
+        </div>
+    </div>
     <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Watermark UI modal and tool entry
- wire modal to `/api/watermark`
- expose functions and update progress

## Testing
- `npm test`
- `cd api && npm install && npm test`
- `cd frontend && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423c2fd9208325ba9b0d3c3f402883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an image watermarking tool, allowing users to add custom text watermarks to images with selectable position and opacity.
  - Added a dedicated modal interface for watermarking, including image upload, text input, position, and opacity controls.
  - Users can download the watermarked image directly after processing.

- **Documentation**
  - Updated progress documentation to reflect completion of the Watermark API UI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->