### PR TITLE
Add image resize modal and update progress

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -22,7 +22,7 @@ This document tracks implemented features from the PRD.
 - 배포 후 `generate-admin-hash.js`로 새 비밀번호 해시를 생성해 보안을 유지합니다.
 - [x] 프런트엔드에 QR 코드 생성 UI를 추가하여 Generate API와 연동했습니다.
 - [x] Watermark API UI 연동을 완료합니다.
-- `openTool('image-resize')`를 실제 이미지 크기 조정 모달로 구현하고 Convert API에 연동합니다.
+- [x] `openTool('image-resize')`를 실제 이미지 크기 조정 모달로 구현하고 Convert API에 연동했습니다.
 - 관리자 패널의 `generateWebsiteCode()` 기능을 완성하여 편집한 콘텐츠를 정적 HTML로 내보냅니다.
 - Cloudflare R2 저장소 정리 함수(`CleanupStorage`)를 타이머 트리거로 배포하여 자동화합니다.
 - 새로 추가되는 모달과 API 연동 로직에 대한 테스트 코드를 작성합니다.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -65,7 +65,11 @@ function showTab(tabName) {
 
 // 도구 열기
 function openTool(toolName) {
-    alert(`${toolName} 도구를 준비 중입니다!`);
+    if (toolName === 'image-resize') {
+        showResizeModal();
+    } else {
+        alert(`${toolName} 도구를 준비 중입니다!`);
+    }
 }
 
 // 파일 변환 모달
@@ -199,6 +203,17 @@ function closeUpscaleModal() {
     document.getElementById('upscaleFile').value = '';
     document.getElementById('upscaleProgress').style.display = 'none';
     document.getElementById('upscaleFill').style.width = '0%';
+}
+
+function showResizeModal() {
+    document.getElementById('resizeModal').classList.add('show');
+}
+
+function closeResizeModal() {
+    document.getElementById('resizeModal').classList.remove('show');
+    document.getElementById('resizeFile').value = '';
+    document.getElementById('resizeProgress').style.display = 'none';
+    document.getElementById('resizeFill').style.width = '0%';
 }
 
 function showZoomModal() {
@@ -667,6 +682,54 @@ async function startUpscale() {
     }
 }
 
+async function startResize() {
+    const fileInput = document.getElementById('resizeFile');
+    const width = document.getElementById('resizeWidth').value;
+    const height = document.getElementById('resizeHeight').value;
+
+    if (!fileInput.files[0]) {
+        alert('이미지를 선택하세요.');
+        return;
+    }
+    if (!width && !height) {
+        alert('너비나 높이를 입력하세요.');
+        return;
+    }
+
+    const file = fileInput.files[0];
+    const ext = (file.name.split('.').pop() || 'png').toLowerCase();
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('targetFormat', ext);
+    if (width) formData.append('width', width);
+    if (height) formData.append('height', height);
+
+    document.getElementById('resizeProgress').style.display = 'block';
+    document.getElementById('resizeFill').style.width = '0%';
+    document.getElementById('resizeStatus').textContent = '서버에 업로드 중...';
+
+    try {
+        const response = await fetch(`${API_BASE}/api/convert`, {
+            method: 'POST',
+            body: formData
+        });
+        if (!response.ok) throw new Error(await response.text());
+
+        document.getElementById('resizeFill').style.width = '50%';
+        document.getElementById('resizeStatus').textContent = '처리 중...';
+
+        const result = await response.json();
+
+        document.getElementById('resizeFill').style.width = '100%';
+        document.getElementById('resizeStatus').innerHTML =
+            `<a href="${result.downloadUrl}" target="_blank">변환된 이미지 다운로드</a>`;
+
+    } catch (err) {
+        document.getElementById('resizeStatus').textContent = `오류: ${err.message}`;
+    }
+}
+
 // API 연결 상태 확인 함수
 async function checkApiConnection() {
     try {
@@ -848,11 +911,14 @@ window.showTab = showTab;
 window.openTool = openTool;
 window.showFileConverter = showFileConverter;
 window.closeConverterModal = closeConverterModal;
+window.showResizeModal = showResizeModal;
+window.closeResizeModal = closeResizeModal;
 window.showUpscaleModal = showUpscaleModal;
 window.closeUpscaleModal = closeUpscaleModal;
 window.showZoomModal = showZoomModal;
 window.closeZoomModal = closeZoomModal;
 window.startConversion = startConversion;
+window.startResize = startResize;
 window.startUpscale = startUpscale;
 window.startZoom = startZoom;
 window.showAdminModal = showAdminModal;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -148,6 +148,43 @@
                 <p class="status-message" id="statusMessage">준비 중...</p>
             </div>
         </div>
+</div>
+
+    <!-- Image Resize Modal -->
+    <div class="converter-modal" id="resizeModal">
+        <div class="converter-content">
+            <button class="close-button" onclick="closeResizeModal()">×</button>
+            <h2 class="converter-header">📐 이미지 크기 조정</h2>
+
+            <div class="converter-section">
+                <label class="converter-label">이미지 선택</label>
+                <input type="file" id="resizeFile" class="file-input" accept="image/*">
+            </div>
+
+            <div class="converter-section">
+                <label class="converter-label">새 크기</label>
+                <div class="size-inputs">
+                    <div class="size-input-group">
+                        <label>너비:</label>
+                        <input type="number" id="resizeWidth" class="size-input" placeholder="px">
+                    </div>
+                    <div class="size-input-group">
+                        <label>높이:</label>
+                        <input type="number" id="resizeHeight" class="size-input" placeholder="px">
+                    </div>
+                </div>
+                <p class="size-hint">한쪽만 입력하면 비율을 유지합니다</p>
+            </div>
+
+            <button id="resizeButton" class="convert-button" onclick="startResize()">크기 조정</button>
+
+            <div class="progress-section" id="resizeProgress" style="display:none;">
+                <div class="progress-bar">
+                    <div class="progress-fill" id="resizeFill"></div>
+                </div>
+                <p class="status-message" id="resizeStatus">준비 중...</p>
+            </div>
+        </div>
     </div>
 
     <!-- Image Upscale Modal -->


### PR DESCRIPTION
## Summary
- implement a new image resize modal in the frontend
- wire `openTool('image-resize')` to show the modal
- call the Convert API to resize images
- expose resize functions globally
- mark resize feature as complete in `docs/PROGRESS.md`

## Testing
- `npm test` at repository root
- `npm install` and `npm test` in `api`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684253523a508325922e473c6da27bd0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an image resizing tool with a dedicated modal, allowing users to upload an image, specify target width and/or height, and download the resized result.
  - Added real-time progress updates and status messages during the resizing process.

- **Documentation**
  - Updated progress documentation to reflect completion of the image resize modal and its integration with the conversion service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->