### PR TITLE
Fix CleanupStorage trigger for SWA deployment

### DIFF
--- a/api/CleanupStorage/function.json
+++ b/api/CleanupStorage/function.json
@@ -1,10 +1,17 @@
 {
   "bindings": [
     {
-      "name": "myTimer",
-      "type": "timerTrigger",
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
       "direction": "in",
-      "schedule": "0 0 3 * * *"
+      "name": "req",
+      "methods": ["post", "options"],
+      "route": "cleanup-storage"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
     }
   ],
   "scriptFile": "index.js"

--- a/api/CleanupStorage/index.js
+++ b/api/CleanupStorage/index.js
@@ -16,9 +16,34 @@ const s3Client = new S3Client({
     }
 });
 
-module.exports = async function (context, myTimer) {
+module.exports = async function (context, req) {
+    context.log('CleanupStorage HTTP 함수가 실행됨');
+
+    const corsHeaders = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Max-Age': '86400'
+    };
+
+    context.res = {
+        headers: corsHeaders
+    };
+
+    if (req.method === 'OPTIONS') {
+        context.res.status = 200;
+        context.res.body = 'OK';
+        return;
+    }
+
+    if (req.method !== 'POST') {
+        context.res.status = 405;
+        context.res.body = { error: 'Method not allowed' };
+        return;
+    }
+
     const timeStamp = new Date().toISOString();
-    context.log('CleanupStorage timer 함수가 실행됨:', timeStamp);
+    context.log('CleanupStorage POST 요청 처리:', timeStamp);
     
     try {
         const now = new Date();
@@ -94,7 +119,11 @@ module.exports = async function (context, myTimer) {
         
         const message = `스토리지 정리 완료: 총 ${totalProcessed}개 파일 중 ${deletedCount}개 만료 파일 삭제됨`;
         context.log(message);
+        context.res.status = 200;
+        context.res.body = { success: true, message };
     } catch (error) {
         context.log.error('스토리지 정리 중 오류 발생:', error);
+        context.res.status = 500;
+        context.res.body = { success: false, error: 'Cleanup failed' };
     }
 };


### PR DESCRIPTION
## Summary
- convert `CleanupStorage` from timer trigger to HTTP trigger
- expose endpoint `/api/cleanup-storage` that runs cleanup when called

## Testing
- `npm test`
- `npm test` in `api/`

------
https://chatgpt.com/codex/tasks/task_e_68426fe90ca083259a0271f643660865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Storage cleanup can now be triggered via an HTTP POST request instead of running on a daily schedule.
  - Added support for CORS and improved HTTP response handling for better integration with external services.

- **Bug Fixes**
  - Improved error handling and response messages for failed cleanup requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->